### PR TITLE
TTGOv2.1.6 changes, finally!

### DIFF
--- a/esp32/boards/make-pins.py
+++ b/esp32/boards/make-pins.py
@@ -141,7 +141,7 @@ class Pins:
                 pin = Pin(row[pinname_col], pin_num)
                 # FIXME: hack to force the SX127x pins to be available
                 if os.getenv("BOARD") in ("LOPY", "HELTEC"):  # For the HELTEC wireless LORA boards
-                    if row[pinname_col] in ('GPIO14', 'GPIO18', 'GPIO26'):
+                    if row[pinname_col] in ('GPIO23', 'GPIO18', 'GPIO26'):
                         pin.board_pin = True
                 else:
                     if row[pinname_col] == 'GPIO17' or row[pinname_col] == 'GPIO18' or row[pinname_col] == 'GPIO23':

--- a/esp32/lora/gpio-board.c
+++ b/esp32/lora/gpio-board.c
@@ -32,14 +32,14 @@ Maintainer: Miguel Luis and Gregory Cristian
 
 #if defined HELTEC
 pin_obj_t *gpio_board_map[NBR_GP_PINS] = {
-        &pin_GPIO14,
+        &pin_GPIO23,
         &pin_GPIO18,
         &pin_GPIO26,
         &pin_GPIO5,
         &pin_GPIO27,
         &pin_GPIO19,
-        &pin_GPI35,
-        &pin_GPI34,
+        &pin_GPIO33,
+        &pin_GPIO32,
 };
 #else
 pin_obj_t *gpio_board_map[NBR_GP_PINS] = {

--- a/esp32/lora/pinName-board.h
+++ b/esp32/lora/pinName-board.h
@@ -35,7 +35,7 @@ Maintainer: Miguel Luis and Gregory Cristian
  */
 #if defined(HELTEC)
     #define MCU_PINS \
-        GPIO14 = 0, GPIO18, GPIO26, GPIO5, GPIO27, GPIO19, GPI35, GPI34, NBR_GP_PINS
+        GPIO23 = 0, GPIO18, GPIO26, GPIO5, GPIO27, GPIO19, GPIO33, GPIO32, NBR_GP_PINS
 #else
     #define MCU_PINS \
         GPIO17 = 0, GPIO18, GPIO23, GPIO5, GPIO27, GPIO19, NBR_GP_PINS

--- a/esp32/main.c
+++ b/esp32/main.c
@@ -180,8 +180,8 @@ void app_main(void) {
     micropy_lpwan_ncs_pin = &pin_GPIO18;
 
     micropy_lpwan_reset_pin_index = 0;
-    micropy_lpwan_reset_pin_num = 14;
-    micropy_lpwan_reset_pin = &pin_GPIO14;
+    micropy_lpwan_reset_pin_num = 23;
+    micropy_lpwan_reset_pin = &pin_GPIO23;
     micropy_lpwan_use_reset_pin = true;
 
     micropy_lpwan_dio_pin_index = 2;
@@ -189,12 +189,12 @@ void app_main(void) {
     micropy_lpwan_dio_pin = &pin_GPIO26;
 
     micropy_lpwan_dio1_pin_index = 6;
-    micropy_lpwan_dio1_pin_num = 35;
-    micropy_lpwan_dio1_pin = &pin_GPI35;
+    micropy_lpwan_dio1_pin_num = 33;
+    micropy_lpwan_dio1_pin = &pin_GPIO33;
 
     micropy_lpwan_dio2_pin_index = 7;
-    micropy_lpwan_dio2_pin_num = 34;
-    micropy_lpwan_dio2_pin = &pin_GPI34;
+    micropy_lpwan_dio2_pin_num = 32;
+    micropy_lpwan_dio2_pin = &pin_GPIO32;
 #else
 #ifndef ESP32_GENERIC
     if (esp32_get_chip_rev() > 0) {


### PR DESCRIPTION
Finally with this changes I made it work! Thank you very much @robert-hh !! Let me buy you a beer for your patience! 

I made the changes that you indicated :
```
drivers/sx127x/sx1276/sx1276.c  No change required
drivers/sx127x/sx1276/sx1276.h  No change required
esp32/main.c                    ! Change gpio numbers 14->23, 35->33, 34->32
esp32/tools/makepkg.sh          No change required
esp32/tools/size_check.sh       No change required
esp32/boards/make-pins.py       !Change GPIO number 14 -> 23
esp32/lora/sx1276-board.h       Line 25 sets the Clock. 0x09 = Crystal, 0x19 = TCXO to be tested (Crystal is the right one)
esp32/lora/board.c              No change required
esp32/lora/spi-board.c          No change required
esp32/lora/sx1272-board.c       No change required
esp32/lora/board.h              No change required
esp32/lora/pinName-board.h      ! Change gpio numbers 14->23, 35->33, 34->32
esp32/lora/sx1276-board.c       No change required
esp32/lora/gpio-board.c         ! Change gpio numbers 14->23, 35->33, 34->32
esp32/mods/machpin.c            No change required
lib/lora/system/spi.h           No change required
```
esp32/application.mk            No change required

Finally the error were in the python side....I have had modified the python test code in order to check what was happening and I have changed something...(dammit!)  I have tried with the simple ABP example from Pycom and it works. Then I tried with your original example an it is working (uplink and downlink):

```
Device was joined (again)
Message:
Sending: b'PKT #000 ++++++++++'
Received: b'\xaa\xaa\xaa', on port: 1
(rx_timestamp=422816209, rssi=-122, snr=-11.0, sfrx=4, sftx=4, tx_trials=3, tx_power=14, tx_time_on_air=134, tx_counter=0, tx_frequency=868500000)
```
I will do more testing, thank you for the support and for the patience!




 